### PR TITLE
Plugin options

### DIFF
--- a/NKScriptingLite.podspec
+++ b/NKScriptingLite.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
 s.name         = "NKScriptingLite"
-s.version      = "0.10.0"
+s.version      = "0.11.0"
 s.summary      = "The universal, open-source, embedded engine"
 s.description  = "NodeKit is the universal, open-source, embedded engine that provides a full ES5 / Node.js instance inside desktop and mobile applications for OS X, iOS, Android, and Windows."
 s.homepage     = "https://github.com/nodekit-io/nodekit"
 s.license      = { :type => 'APACHE-2', :file => 'LICENSE' }
 s.author       = { "OffGrid Networks" => 'admin@offgridn.com' }
-s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin-lite.git", :tag => "0.10.0" }
+s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin-lite.git", :tag => s.version.to_s }
 
 s.ios.deployment_target = '9.0'
 s.osx.deployment_target = '10.11'

--- a/NodeKitLite.xcodeproj/project.pbxproj
+++ b/NodeKitLite.xcodeproj/project.pbxproj
@@ -584,7 +584,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				VALID_ARCHS = " arm64 armv7 armv7s i386 x86_64";
 			};
@@ -609,7 +609,7 @@
 				PRODUCT_NAME = NKScripting;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				VALID_ARCHS = " arm64 armv7 armv7s i386 x86_64";
 			};

--- a/src/nodekit/NKScriptingLite/NKJSContext.swift
+++ b/src/nodekit/NKScriptingLite/NKJSContext.swift
@@ -115,9 +115,9 @@ extension NKJSContext: NKScriptContext {
         
         plugins[plugin.namespace] = plugin
         
-        guard let jspath: String = plugin.options["js"] as? String else { return; }
+        guard let jspath: String = plugin.sourceJS else { return }
         
-        guard let js = NKStorage.getResource(jspath, type(of: plugin)) else { return; }
+        guard let js = NKStorage.getResource(jspath, type(of: plugin)) else { return }
         
         self.injectJavaScript(
             NKScriptSource(

--- a/src/nodekit/NKScriptingLite/NKJSTimer.swift
+++ b/src/nodekit/NKScriptingLite/NKJSTimer.swift
@@ -34,10 +34,8 @@ import JavaScriptCore
 
 @objc class NKJSTimer: NSObject, TimerJSExport, NKNativePlugin, NKDisposable {
     
-    let namespace: String = "NodeKitTimer"
-    let options: [String : AnyObject] = [
-        "js": "lib-scripting.nkar/lib-scripting/timer.js" as NSString
-    ]
+    public let namespace: String = "NodeKitTimer"
+    public let sourceJS: String? = "lib-scripting.nkar/lib-scripting/timer.js"
     
     var timers = [String: Timer]()
     var callbacks = [String: JSValue]()

--- a/src/nodekit/NKScriptingLite/NKNativePlugin.swift
+++ b/src/nodekit/NKScriptingLite/NKNativePlugin.swift
@@ -21,14 +21,14 @@ import JavaScriptCore
 /*
  A native object that will be registered under global[namespace] and
  callable from JavaScript.
- Options can include a JavaScript source file to be loaded like so:
- ["js": "path/to/file.js" as NSString]
+ The path to a cooresponding JavaScript file can be supplied under sourceJS
+ if needed. This file will be evaluated after the plugin is loaded.
  */
 @objc public protocol NKNativePlugin: AnyObject {
     
     var namespace: String { get }
     
-    var options: [String: AnyObject] { get }
+    var sourceJS: String? { get }
 }
 
 /*

--- a/src/nodekit/NKScriptingLite/NKStorage.swift
+++ b/src/nodekit/NKScriptingLite/NKStorage.swift
@@ -38,10 +38,7 @@ open class NKStorage: NSObject, NKNativePlugin {
     // PUBLIC METHODS NATIVE SIDE ONLY
     
     public let namespace = "io.nodekit.scripting.storage"
-    
-    public var options: [String : AnyObject] = [
-        "js": "lib-scripting.nkar/lib-scripting/native_module.js" as NSString
-    ]
+    public let sourceJS: String? = "lib-scripting.nkar/lib-scripting/native_module.js"
     
     open static var mainBundle = NKStorage.mainBundle_()
 

--- a/src/nodekit/platform/Info.plist
+++ b/src/nodekit/platform/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/src/samples/sample-NKScripting/platform-darwin/SamplePlugin.swift
+++ b/src/samples/sample-NKScripting/platform-darwin/SamplePlugin.swift
@@ -30,9 +30,7 @@ import NKScripting
 class SamplePlugin: NSObject, SamplePluginProtocol {
     
     let namespace: String = "io.nodekit.test"
-    let options: [String : AnyObject] = [
-        "PluginBridge": NKScriptExportType.nkScriptExport.rawValue as NSNumber
-    ]
+    let sourceJS: String? = nil
     
     var nkScriptObject: JSValue? {
         
@@ -48,7 +46,7 @@ class SamplePlugin: NSObject, SamplePluginProtocol {
     }
 
     func logconsole(_ text: AnyObject?) -> Void {
-        print(text as? String! ?? "")
+        print(text as? String ?? "")
     }
 
     func alertSync(_ text: AnyObject?) -> String {


### PR DESCRIPTION
Preferring to use a known property for NKNativePlugin sourceJS file. This is less error-prone than a dictionary of options which can't be checked for typos, etc. Considering the options are being used entirely in native code, we don't need the dynamism of a dictionary here. Also, I've disabled @objc inference which should reduce the code size significantly and resolves compiler warnings.